### PR TITLE
refactor: centralize configuration using LazyLock static variables

### DIFF
--- a/demo-oauth2/src/handlers.rs
+++ b/demo-oauth2/src/handlers.rs
@@ -1,8 +1,7 @@
 use askama::Template;
-use axum::{extract::State, http::StatusCode, response::Html};
+use axum::{http::StatusCode, response::Html};
+use liboauth2::OAUTH2_ROUTE_PREFIX;
 use libsession::User;
-
-use crate::state::AppState;
 
 #[derive(Template)]
 #[template(path = "index_user.j2")]
@@ -25,16 +24,13 @@ struct ProtectedTemplate<'a> {
     auth_route_prefix: &'a str,
 }
 
-pub(crate) async fn index(
-    State(s): State<AppState>,
-    user: Option<User>,
-) -> Result<Html<String>, (StatusCode, String)> {
+pub(crate) async fn index(user: Option<User>) -> Result<Html<String>, (StatusCode, String)> {
     match user {
         Some(u) => {
             let message = format!("Hey {}!", u.name);
             let template = IndexTemplateUser {
                 message: &message,
-                auth_route_prefix: &s.oauth2_state.oauth2_params.oauth2_route_prefix,
+                auth_route_prefix: OAUTH2_ROUTE_PREFIX.as_str(),
             };
             let html = Html(
                 template
@@ -47,7 +43,7 @@ pub(crate) async fn index(
             let message = "Click the Login button below.".to_string();
             let template = IndexTemplateAnon {
                 message: &message,
-                auth_route_prefix: &s.oauth2_state.oauth2_params.oauth2_route_prefix,
+                auth_route_prefix: OAUTH2_ROUTE_PREFIX.as_str(),
             };
             let html = Html(
                 template
@@ -59,13 +55,10 @@ pub(crate) async fn index(
     }
 }
 
-pub(crate) async fn protected(
-    State(s): State<AppState>,
-    user: User,
-) -> Result<Html<String>, (StatusCode, String)> {
+pub(crate) async fn protected(user: User) -> Result<Html<String>, (StatusCode, String)> {
     let template = ProtectedTemplate {
         user,
-        auth_route_prefix: &s.oauth2_state.oauth2_params.oauth2_route_prefix,
+        auth_route_prefix: OAUTH2_ROUTE_PREFIX.as_str(),
     };
     let html = Html(
         template

--- a/demo-oauth2/src/main.rs
+++ b/demo-oauth2/src/main.rs
@@ -3,7 +3,7 @@ use dotenv::dotenv;
 use std::sync::Arc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use liboauth2::oauth2_state_init;
+use liboauth2::{oauth2_state_init, OAUTH2_ROUTE_PREFIX};
 use libsession::session_state_init;
 
 mod handlers;
@@ -39,16 +39,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::process::exit(1);
         });
 
-    let app_state = AppState {
-        session_state,
-        oauth2_state: oauth2_state.clone(),
-    };
+    let app_state = AppState { session_state };
     let app = Router::new()
         .route("/", get(index))
         .route("/protected", get(protected))
         .with_state(app_state.clone())
         .nest(
-            &oauth2_state.oauth2_params.oauth2_route_prefix,
+            OAUTH2_ROUTE_PREFIX.as_str(),
             liboauth2::router(oauth2_state.clone()),
         )
         .with_state(oauth2_state);

--- a/demo-oauth2/src/state.rs
+++ b/demo-oauth2/src/state.rs
@@ -3,13 +3,11 @@ use axum::{
     http::request::Parts,
     response::{IntoResponse, Redirect, Response},
 };
-use liboauth2::OAuth2State;
 use libsession::{SessionState, User};
 
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub(crate) session_state: SessionState,
-    pub(crate) oauth2_state: OAuth2State,
 }
 
 pub(crate) struct AuthRedirect;

--- a/liboauth2/src/config.rs
+++ b/liboauth2/src/config.rs
@@ -1,4 +1,7 @@
-use std::{env, sync::Arc};
+use std::{
+    env,
+    sync::{Arc, LazyLock},
+};
 use tokio::sync::Mutex;
 
 use crate::errors::AppError;
@@ -6,17 +9,39 @@ use crate::storage::TokenStoreType;
 use crate::types::*;
 use libsession::SessionState;
 
-static OAUTH2_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
-static OAUTH2_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+// static OAUTH2_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+// static OAUTH2_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 pub(crate) static OAUTH2_USERINFO_URL: &str = "https://www.googleapis.com/userinfo/v2/me";
 
-static OAUTH2_QUERY_STRING: &str = "response_type=code\
-&scope=openid+email+profile\
-&response_mode=form_post\
-&access_type=online\
-&prompt=consent";
-// &response_mode=form_post\
-// &response_mode=query\
+pub(crate) static OAUTH2_AUTH_URL: LazyLock<String> = LazyLock::new(|| {
+    env::var("OAUTH2_AUTH_URL")
+        .ok()
+        .unwrap_or("https://accounts.google.com/o/oauth2/v2/auth".to_string())
+});
+pub(crate) static OAUTH2_TOKEN_URL: LazyLock<String> = LazyLock::new(|| {
+    env::var("OAUTH2_TOKEN_URL")
+        .ok()
+        .unwrap_or("https://oauth2.googleapis.com/token".to_string())
+});
+
+static OAUTH2_SCOPE: LazyLock<String> =
+    LazyLock::new(|| std::env::var("OAUTH2_SCOPE").unwrap_or("openid+email+profile".to_string()));
+
+static OAUTH2_RESPONSE_MODE: LazyLock<String> =
+    LazyLock::new(|| std::env::var("OAUTH2_RESPONSE_MODE").unwrap_or("form_post".to_string()));
+
+static OAUTH2_RESPONSE_TYPE: LazyLock<String> =
+    LazyLock::new(|| std::env::var("OAUTH2_RESPONSE_TYPE").unwrap_or("code".to_string()));
+
+pub(crate) static OAUTH2_QUERY_STRING: LazyLock<String> = LazyLock::new(|| {
+    let mut query_string = "".to_string();
+    query_string.push_str(&format!("&response_type={}", *OAUTH2_RESPONSE_TYPE));
+    query_string.push_str(&format!("&scope={}", *OAUTH2_SCOPE));
+    query_string.push_str(&format!("&response_mode={}", *OAUTH2_RESPONSE_MODE));
+    query_string.push_str(&format!("&access_type={}", "online"));
+    query_string.push_str(&format!("&prompt={}", "consent"));
+    query_string
+});
 
 // Supported parameters:
 // response_type: code
@@ -27,37 +52,47 @@ static OAUTH2_QUERY_STRING: &str = "response_type=code\
 
 // "__Host-" prefix are added to make cookies "host-only".
 
-// pub(super) static SESSION_COOKIE_NAME: &str = "__Host-SessionId";
-// static SESSION_COOKIE_MAX_AGE: u64 = 600; // 10 minutes
-pub(crate) static CSRF_COOKIE_NAME: &str = "__Host-CsrfId";
-pub(crate) static CSRF_COOKIE_MAX_AGE: u64 = 60; // 60 seconds
+pub(crate) static OAUTH2_CSRF_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("OAUTH2_CSRF_COOKIE_NAME")
+        .ok()
+        .unwrap_or("__Host-CsrfId".to_string())
+});
+
+pub(crate) static OAUTH2_CSRF_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {
+    std::env::var("OAUTH2_CSRF_COOKIE_MAX_AGE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(60) // Default to 60 seconds if not set or invalid
+});
+
+pub static OAUTH2_ROUTE_PREFIX: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("OAUTH2_ROUTE_PREFIX")
+        .ok()
+        .unwrap_or("/oauth2".to_string())
+});
+
+pub(crate) static OAUTH2_REDIRECT_URI: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}{}/authorized",
+        env::var("ORIGIN").expect("Missing ORIGIN!"),
+        OAUTH2_ROUTE_PREFIX.as_str()
+    )
+});
+
+pub(crate) static OAUTH2_GOOGLE_CLIENT_ID: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("OAUTH2_GOOGLE_CLIENT_ID").expect("OAUTH2_GOOGLE_CLIENT_ID must be set")
+});
+
+pub(crate) static OAUTH2_GOOGLE_CLIENT_SECRET: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("OAUTH2_GOOGLE_CLIENT_SECRET").expect("OAUTH2_GOOGLE_CLIENT_SECRET must be set")
+});
 
 pub async fn oauth2_state_init(session_state: Arc<SessionState>) -> Result<OAuth2State, AppError> {
-    let oauth2_route_prefix =
-        env::var("OAUTH2_ROUTE_PREFIX").expect("Missing OAUTH2_ROUTE_PREFIX!");
-
-    let oauth2_params = OAuth2Params {
-        client_id: env::var("CLIENT_ID").expect("Missing CLIENT_ID!"),
-        client_secret: env::var("CLIENT_SECRET").expect("Missing CLIENT_SECRET!"),
-        redirect_uri: format!(
-            "{}{}/authorized",
-            env::var("ORIGIN").expect("Missing ORIGIN!"),
-            oauth2_route_prefix
-        ),
-        auth_url: OAUTH2_AUTH_URL.to_string(),
-        token_url: OAUTH2_TOKEN_URL.to_string(),
-        query_string: OAUTH2_QUERY_STRING.to_string(),
-        oauth2_route_prefix,
-        csrf_cookie_name: CSRF_COOKIE_NAME.to_string(),
-        csrf_cookie_max_age: CSRF_COOKIE_MAX_AGE,
-    };
-
     let token_store = TokenStoreType::from_env()?.create_store().await?;
     token_store.init().await?;
 
     Ok(OAuth2State {
         token_store: Arc::new(Mutex::new(token_store)),
-        oauth2_params,
         session_state,
     })
 }

--- a/liboauth2/src/lib.rs
+++ b/liboauth2/src/lib.rs
@@ -7,5 +7,5 @@ mod storage;
 mod types;
 
 pub use axum::router;
-pub use config::oauth2_state_init;
+pub use config::{oauth2_state_init, OAUTH2_ROUTE_PREFIX};
 pub use types::OAuth2State;

--- a/liboauth2/src/types.rs
+++ b/liboauth2/src/types.rs
@@ -3,23 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Clone, Debug)]
-pub struct OAuth2Params {
-    pub client_id: String,
-    pub client_secret: String,
-    pub redirect_uri: String,
-    pub auth_url: String,
-    pub(crate) token_url: String,
-    pub query_string: String,
-    pub oauth2_route_prefix: String,
-    pub csrf_cookie_name: String,
-    pub csrf_cookie_max_age: u64,
-}
-
 #[derive(Clone)]
 pub struct OAuth2State {
     pub(crate) token_store: Arc<Mutex<Box<dyn crate::storage::CacheStoreToken>>>,
-    pub oauth2_params: OAuth2Params,
     pub session_state: Arc<libsession::SessionState>,
 }
 

--- a/libsession/src/axum/extractor.rs
+++ b/libsession/src/axum/extractor.rs
@@ -33,7 +33,9 @@ impl FromRequestParts<SessionState> for User {
             .map_err(|_| AuthRedirect)?;
 
         // Get session from cookie
-        let session_cookie = cookies.get(SESSION_COOKIE_NAME).ok_or(AuthRedirect)?;
+        let session_cookie = cookies
+            .get(SESSION_COOKIE_NAME.as_str())
+            .ok_or(AuthRedirect)?;
         let store_guard = store.lock().await;
         let session = store_guard
             .get(session_cookie)

--- a/libsession/src/config.rs
+++ b/libsession/src/config.rs
@@ -1,27 +1,26 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::sync::Mutex;
 
 use crate::errors::AppError;
-use crate::types::{SessionParams, SessionState, SessionStoreType};
+use crate::types::{SessionState, SessionStoreType};
 
-pub(crate) static SESSION_COOKIE_NAME: &str = "__Host-SessionId";
-pub(crate) static SESSION_COOKIE_MAX_AGE: u64 = 600; // 10 minutes
-pub(crate) static CSRF_COOKIE_NAME: &str = "__Host-CsrfId";
-pub(crate) static CSRF_COOKIE_MAX_AGE: u64 = 60; // 60 seconds
+pub static SESSION_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("SESSION_COOKIE_NAME")
+        .ok()
+        .unwrap_or("__Host-SessionId".to_string())
+});
+pub static SESSION_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {
+    std::env::var("SESSION_COOKIE_MAX_AGE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(600) // Default to 10 minutes if not set or invalid
+});
 
 pub async fn session_state_init() -> Result<SessionState, AppError> {
-    let session_params = SessionParams {
-        session_cookie_name: SESSION_COOKIE_NAME.to_string(),
-        csrf_cookie_name: CSRF_COOKIE_NAME.to_string(),
-        session_cookie_max_age: SESSION_COOKIE_MAX_AGE,
-        csrf_cookie_max_age: CSRF_COOKIE_MAX_AGE,
-    };
-
     let session_store = SessionStoreType::from_env()?.create_store().await?;
     session_store.init().await?;
 
     Ok(SessionState {
         session_store: Arc::new(Mutex::new(session_store)),
-        session_params,
     })
 }

--- a/libsession/src/lib.rs
+++ b/libsession/src/lib.rs
@@ -6,7 +6,7 @@ mod session;
 mod storage;
 mod types;
 
-pub use config::session_state_init;
+pub use config::{session_state_init, SESSION_COOKIE_MAX_AGE, SESSION_COOKIE_NAME};
 pub use errors::AppError;
 pub use session::{create_new_session, delete_session_from_store, prepare_logout_response};
 pub use types::{SessionState, User};

--- a/libsession/src/types.rs
+++ b/libsession/src/types.rs
@@ -3,18 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Clone, Debug)]
-pub struct SessionParams {
-    pub session_cookie_name: String,
-    pub csrf_cookie_name: String,
-    pub session_cookie_max_age: u64,
-    pub csrf_cookie_max_age: u64,
-}
-
 #[derive(Clone)]
 pub struct SessionState {
     pub(crate) session_store: Arc<Mutex<Box<dyn crate::storage::CacheStoreSession>>>,
-    pub session_params: SessionParams,
 }
 
 // The user data we'll get back from Google


### PR DESCRIPTION
- Replace OAuth2Params and SessionParams structs with LazyLock static configuration
- Move configuration values to config modules with environment variable support
- Simplify OAuth2State and SessionState by removing params structs
- Add default values for all configurable parameters
- Make cookie names and TTLs configurable via environment variables

This change improves maintainability by centralizing configuration and reduces memory usage by removing redundant configuration structs from state objects.