### PR TITLE
feat(session): Add create_session_with_uid function

### DIFF
--- a/libsession/src/lib.rs
+++ b/libsession/src/lib.rs
@@ -10,6 +10,7 @@ mod types;
 pub use config::{SESSION_COOKIE_MAX_AGE, SESSION_COOKIE_NAME}; // Required for cookie configuration
 pub use errors::{AppError, SessionError}; // Required for error handling
 pub use session::{
+    create_session_with_uid,
     // create_new_session,
     create_session_with_user,
     delete_session_from_store,

--- a/libsession/src/session/core.rs
+++ b/libsession/src/session/core.rs
@@ -83,9 +83,13 @@ pub async fn create_session_with_user(user_data: SessionUser) -> Result<HeaderMa
         .map_err(|e| AppError(anyhow::Error::from(e)))?
         .into();
 
+    create_session_with_uid(&user.id).await
+}
+
+pub async fn create_session_with_uid(user_id: &str) -> Result<HeaderMap, AppError> {
     // Create minimal session info
     let session_info = SessionInfo {
-        user_id: user.id,
+        user_id: user_id.to_string(),
         expires_at: Utc::now() + Duration::seconds(*SESSION_COOKIE_MAX_AGE as i64),
     };
 

--- a/libsession/src/session/mod.rs
+++ b/libsession/src/session/mod.rs
@@ -1,6 +1,7 @@
 mod core;
 
 pub use core::{
+    create_session_with_uid,
     // create_new_session,
     create_session_with_user,
     delete_session_from_store,


### PR DESCRIPTION
- Extract session creation logic into create_session_with_uid function
- Refactor create_session_with_user to use the new function
- Re-export create_session_with_uid for external use

This change allows creating sessions with just a user ID string, providing more flexibility in session management.